### PR TITLE
remove reference to ODI for now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-In the context of SAP's Open Documentation Initiative, we are open to contributions to this documentation repository.
+We are open to contributions to this documentation repository.
 
 We recognize contributions in two forms:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-This repository contains the Contribution Guidelines documentation, which itself is released for external contributions under the SAP Open Documentation Initiative. You can learn how to contribute by reading the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
+This repository contains the Contribution Guidelines documentation, which itself is released for external contributions. You can learn how to contribute by reading the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 
 You can browse the documentation directly in the [`docs/`](docs/) directory in this repository, or read the content on the SAP Help Portal. <!--INSERT LINK-->
 


### PR DESCRIPTION
Until we have a page that we can link to, it might be better to remove references to the Open Documentation Initiative.
