### PR TITLE
change loio id

### DIFF
--- a/docs/metadata.yaml
+++ b/docs/metadata.yaml
@@ -3,7 +3,7 @@ deliverable:
   label: Open Documentation Initiative
   language: en-US
   lastmodifiedby: dj.adams@sap.com
-  loio: doc-contribution-guidelines
+  loio: contribution-guidelines
   owner: i347491
   product: open-documentation-initiative
   rootfile: upload.zip
@@ -20,7 +20,7 @@ outputmeta:
   version_sapid: null
 mapref:
   - title: "SAP Documentation Contribution Guidelines"
-    loio: "doc-contribution-guidelines"
+    loio: "contribution-guidelines"
     shortdesc: "Documentation contribution guidelines"
 nav:
   - title: "Contribution Guidelines"


### PR DESCRIPTION
We don't need the 'doc-' prefix in the LOIO id, and removing this prefix makes for a neater URL on the SAP Help Portal.
