### PR TITLE
don't print trailing newline on echo

### DIFF
--- a/.github/workflows/merged-pr-labeler.yaml
+++ b/.github/workflows/merged-pr-labeler.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - id: auth_gh
         name: Authenticate gh to repo
-        run: echo ${{ secrets.PAT }} | gh auth login --with-token
+        run: echo -n ${{ secrets.PAT }} | gh auth login --with-token
 
       - id: clean_clone
         name: Clean working area and clone repo


### PR DESCRIPTION
This should ideally prevent issues when piping into `gh auth login --with-token`