### PR TITLE
add cond to check if on github.com

### DIFF
--- a/.github/workflows/community-id-requester.yaml
+++ b/.github/workflows/community-id-requester.yaml
@@ -29,7 +29,7 @@ jobs:
     env:
       LABEL: "contribution"
     runs-on: ubuntu-20.04
-    if: github.event.label.name == 'contribution'
+    if: contains(github.repositoryUrl, 'github.com') && github.event.label.name == 'contribution'
 
     steps:
 

--- a/.github/workflows/merged-pr-labeler.yaml
+++ b/.github/workflows/merged-pr-labeler.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
 
   assign-label-on-merge:
-    if: github.event.pull_request.merged
+    if: contains(github.repositoryUrl, 'github.com') && github.event.pull_request.merged
     env:
       LABEL: "contribution"
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Similar to the check we have in the `sync-internal` workflow, we only want these jobs to run on the external repo so this PR adds appropriate condition expressions.
