### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Administration
+*       @SAP-docs/contribution-guidelines-admin
+
+# Documentation content
+docs/   @SAP-docs/contribution-guidelines-team


### PR DESCRIPTION
To organise reviews by owners, focusing on the documentation content owner team for everything in `docs/`, and the admin team for everything else.
