### PR TITLE
add markdown linting, using markdownlint

### DIFF
--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   main:
+    if: contains(github.repositoryUrl, 'github.com')
     runs-on: ubuntu-20.04
     steps:
 

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -14,6 +14,7 @@ name: Markdown linter
 # rule is also employed to check title case.
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
 

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -1,0 +1,47 @@
+name: Markdown linter
+
+# What the execution context is:
+# The creation of a pull request. Can also be triggered manually.
+
+# What it does:
+# Performs Markdown linting on the content of the pull request.
+
+# Why we need it:
+# To maintain a level of consistency in the markup content.
+
+# What's important to know:
+# As well as the rules defined in the configuration, a custom
+# rule is also employed to check title case.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+
+    - id: checkout_repo
+      name: Check out the repository content
+      uses: actions/checkout@v2
+
+    - id: add_matcher
+      name: Add the matcher for markdownlint style message output
+      run: "echo ::add-matcher::.github/workflows/markdownlint/problem-matcher.json"
+
+    - id: install_linter
+      name: Install linting tool and custom rule
+      run: |
+        npm install \
+          --no-package-lock \
+          --no-save \
+          markdownlint-cli markdownlint-rule-titlecase
+
+    - id: run_linter
+      name: Run linter with specific rules, on the docs/ content
+      run: |
+        npx markdownlint \
+          --config .github/workflows/markdownlint/config.yaml \
+          --rules markdownlint-rule-titlecase \
+          docs/

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -17,6 +17,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths: 'docs/**'
 
 jobs:
   main:

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -9,3 +9,4 @@ no-missing-space-atx: true
 no-multiple-space-atx: true
 blanks-around-lists: true
 no-alt-text: true
+titlecase-rule: true

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -1,0 +1,12 @@
+# All rules are inactive by default.
+default: false
+
+# These specific rules are active.
+# See https://github.com/DavidAnson/markdownlint#rules--aliases for details.
+heading-increment: true
+no-reversed-links: true
+no-missing-space-atx: true
+no-multiple-space-atx: true
+blanks-around-headings: true
+blanks-around-lists: true
+no-alt-text: true

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -7,6 +7,5 @@ heading-increment: true
 no-reversed-links: true
 no-missing-space-atx: true
 no-multiple-space-atx: true
-blanks-around-headings: true
 blanks-around-lists: true
 no-alt-text: true

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -7,6 +7,4 @@ heading-increment: true
 no-reversed-links: true
 no-missing-space-atx: true
 no-multiple-space-atx: true
-blanks-around-lists: true
-no-alt-text: true
 titlecase-rule: true

--- a/.github/workflows/markdownlint/problem-matcher.json
+++ b/.github/workflows/markdownlint/problem-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "markdownlint",
+      "pattern": [
+        {
+          "regexp": "([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/docs/content-contribution/markdown-basics.md
+++ b/docs/content-contribution/markdown-basics.md
@@ -2,7 +2,7 @@
 
 [Markdown][markdown] is a lightweight markup language that is simple enough to master and can be edited in any text editor. In order to make it as easy as possible for you to collaborate with us, and offer contributions of content, the SAP documentation sources are presented in Markdown.
 
-## Learning from Examples
+## Learning From Examples
 
 Even more important than being simple to master, Markdown is also easy to read. This has immediate benefits. Most importantly for collaborating with us on documentation is that when editing the source for a particular page of SAP documentation, you're able to view the Markdown source directly. This helps enormously because you can see how the different Markdown elements are used, and where, and these can become examples for you to build upon.
 

--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -184,3 +184,29 @@ Standard Markdown supports blockquotes, often used to highlight additional infor
   > Do not manually alter localization files. Doing so may cause unpredictable results, including data loss.
 
 </details>
+
+## Markdown Linting Rules
+
+We run checks on Markdown content when it is added or changed. This checking process, known as linting, runs automatically when pull requests are created, and help keep the use of markup consistent. The linting process is directed by rules that are used to check the Markdown. There are standard and custom rules.
+
+### Standard Rules
+
+The standard rules used are described in the following table; the rule names refer to the technical identifiers used in the configuration.
+
+|Rule Description|Rule Name|
+|-|-|
+|Heading levels should only increment by one level at a time|`heading-increment`|
+|The syntax for links should be the right way round|`no-reversed-links`|
+|There must be a space after the hash or hashes on a heading|`no-missing-space-atx`|
+|There must be only a single space after the hash or hashes on a heading|`no-multiple-space-atx`|
+|Headings should be surrounded by blank lines|`blanks-around-headings`|
+|Lists should be surrounded by blank lines|`blanks-around-lists`|
+|Images should have alternate text|`no-alt-text`|
+
+For more information on these rules, refer to the [Markdown linting rules documentation](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).
+
+### Custom Rules
+
+There are custom rules that can be used; these rules are implemented with custom extensions used with the linting tool. Currently there is only a single custom rule in use:
+
+* Headings should be written using title case.

--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -199,7 +199,6 @@ The standard rules used are described in the following table; the rule names ref
 |The syntax for links should be the right way round|`no-reversed-links`|
 |There must be a space after the hash or hashes on a heading|`no-missing-space-atx`|
 |There must be only a single space after the hash or hashes on a heading|`no-multiple-space-atx`|
-|Headings should be surrounded by blank lines|`blanks-around-headings`|
 |Lists should be surrounded by blank lines|`blanks-around-lists`|
 |Images should have alternate text|`no-alt-text`|
 

--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -187,7 +187,7 @@ Standard Markdown supports blockquotes, often used to highlight additional infor
 
 ## Markdown Linting Rules
 
-We run checks on Markdown content when it is added or changed. This checking process, known as linting, runs automatically when pull requests are created, and help keep the use of markup consistent. The linting process is directed by rules that are used to check the Markdown. There are standard and custom rules.
+We run checks on Markdown content when it is added or changed using the [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint) tool. This checking process, known as linting, runs automatically when pull requests are created, and help keep the use of markup consistent. The linting process is directed by rules that are used to check the Markdown. There are standard and custom rules.
 
 ### Standard Rules
 

--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -98,14 +98,14 @@ Use backticks (\`) for field names, and field values.
 
 ## Code Snippet Formatting
 
-### Don't include the command prompt
+### Don't Include the Command Prompt
 
 |  Do  | Don't |
 |:---|:---|
 | `cf marketplace`  | `$ cf marketplace` |
 
 
-### Separate commands from output
+### Separate Commands From Output
 
 > ### Example
 >


### PR DESCRIPTION
- new workflow definition to run the checks
- new directory to hold markdownlint specific configuration
- rule configuration for the markdownlint tool
- a problem-matcher to associate markdownlint output with the content
- a new section in the Style Guidelines

See also https://qmacro.org/2021/05/14/notes-on-markdown-linting-part-2/.
