### PR TITLE
start using GitHub app based auth

### DIFF
--- a/.github/workflows/community-id-requester.yaml
+++ b/.github/workflows/community-id-requester.yaml
@@ -34,11 +34,18 @@ jobs:
 
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.token_gen.outputs.app_token }}
 
       - id: issue_details
         name: Determine related details if issue
@@ -60,7 +67,7 @@ jobs:
 
       - id: auth_gh
         name: Authenticate gh to repo
-        run: echo -n ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
       - id: count_label_additions
         name: Count number of times label has been added

--- a/.github/workflows/disallowed-content-checks.yaml
+++ b/.github/workflows/disallowed-content-checks.yaml
@@ -29,13 +29,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          token: ${{ steps.token_gen.outputs.app_token }}
 
       - id: auth_gh
         name: Authenticate gh to repo
-        run: echo -n ${{ secrets.SAPDOCS_Q_PAT_REPO_READORG }} | gh auth login --with-token
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
       - id: check_membership
         name: Check team membership of PR author
@@ -43,7 +52,10 @@ jobs:
           team: 'admin'
         run: |
           IFS='/' read -r owner repository <<< "$GITHUB_REPOSITORY"
-          if gh api "/orgs/$owner/teams/${repository}-${team}/memberships/$GITHUB_ACTOR"; then
+          endpoint="/orgs/$owner/teams/${repository}-${team}/memberships/$GITHUB_ACTOR"
+          echo "Checking '$endpoint'"
+          if gh api "$endpoint"; then
+            echo "$GITHUB_ACTOR is member of ${owner}'s team '${repository}-${team}'"
             echo "is_team_member=true" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/merged-pr-labeler.yaml
+++ b/.github/workflows/merged-pr-labeler.yaml
@@ -29,13 +29,22 @@ jobs:
 
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.token_gen.outputs.app_token }}
+
+      - id: auth_gh
+        name: Authenticate gh to repo
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
       - id: assign_label
-        run: |
-          echo -n ${{ secrets.PAT }} | gh auth login --with-token
-          gh pr edit ${{ github.event.number }} --add-label "$LABEL"
+        run: gh pr edit ${{ github.event.number }} --add-label "$LABEL"


### PR DESCRIPTION
This is a WIP PR getting ready for us to move from an access-token based approach to workflow activity auth to a GitHub Apps based approach.

- generate token with machine-learning-apps/actions-app-token
- use `SAP_CODOC_APP_ID` and `SAP_CODOC_APP_PEM_BASE64` (org-level) secrets

Activities

- [x] Get SAP-codoc app up and installed
- [x] Modify / extend current workflows (contents of this PR)
- [ ] (After merging) Cleanup existing and now defunct access token secrets `PAT` and `SAPDOCS_Q_PAT_REPO_READORG`

