### PR TITLE
limit Markdown linting scope

### DIFF
--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -50,10 +50,10 @@ jobs:
           markdownlint-cli markdownlint-rule-titlecase
 
     - id: run_linter
-      if: steps.check_files_changed.outputs.changed
+      if: steps.check_files_changed.outputs.changed_files
       name: Run linter with specific rules, on the docs/ content
       run: |
         npx markdownlint \
           --config .github/workflows/markdownlint/config.yaml \
           --rules markdownlint-rule-titlecase \
-          ${{ steps.check_files_changed.outputs.changed }}
+          ${{ steps.check_files_changed.outputs.changed_files }}

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -29,6 +29,14 @@ jobs:
       name: Check out the repository content
       uses: actions/checkout@v2
 
+    - id: check_files_changed
+      uses: dorny/paths-filter@v2
+      with:
+        list-files: 'escape'
+        filters: |
+          changed:
+            - 'docs/**'
+
     - id: add_matcher
       name: Add the matcher for markdownlint style message output
       run: "echo ::add-matcher::.github/workflows/markdownlint/problem-matcher.json"
@@ -42,9 +50,10 @@ jobs:
           markdownlint-cli markdownlint-rule-titlecase
 
     - id: run_linter
+      if: steps.check_files_changed.outputs.changed
       name: Run linter with specific rules, on the docs/ content
       run: |
         npx markdownlint \
           --config .github/workflows/markdownlint/config.yaml \
           --rules markdownlint-rule-titlecase \
-          docs/
+          ${{ steps.check_files_changed.outputs.changed }}


### PR DESCRIPTION
- use action to determine list of files changed
- specify that file list when invoking the linter

Addresses #49.

Note that we use the 'escape' value for `list-files` so that we can safely pass a list of files to the linter on the command line.
