### PR TITLE
Use the official badge names

### DIFF
--- a/docs/recognition.md
+++ b/docs/recognition.md
@@ -6,9 +6,9 @@ In addition to the many [missions and badges][missions-badges] already available
 
 In [SAP Community][sap-community] there are two badges relating to community contributions to documentation.
 
-* **Documentation feedback contribution** badge: Earn this badge when you provide feedback that leads to an improvement in the documentation.
+* **Open Documentation Initiative – Provide Feedback** badge: Earn this badge when you provide feedback that leads to an improvement in the documentation.
 
-* **Documentation content contribution** badge: Earn this badge when you contribute content using the pull request method. The pull request has to be merged and included in the documentation before this badge is awarded.
+* **Open Documentation Initiative – Contribute Content** badge: Earn this badge when you contribute content using the pull request method. The pull request has to be merged and included in the documentation before this badge is awarded.
 
 ## Your SAP Community Profile
 


### PR DESCRIPTION
The badge names in https://community.sap.com/resources/missions-badges?q=documentation are different to what they're described until now here.

I think it would be good to align the names.