### PR TITLE
check repo permission level, not team membership

### DIFF
--- a/.github/workflows/disallowed-content-checks.yaml
+++ b/.github/workflows/disallowed-content-checks.yaml
@@ -46,22 +46,15 @@ jobs:
         name: Authenticate gh to repo
         run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
-      - id: check_membership
-        name: Check team membership of PR author
-        env:
-          team: 'admin'
+      - id: determine_permission
+        name: Look up actor's repository permission level
         run: |
-          IFS='/' read -r owner repository <<< "$GITHUB_REPOSITORY"
-          endpoint="/orgs/$owner/teams/${repository}-${team}/memberships/$GITHUB_ACTOR"
-          echo "Checking '$endpoint'"
-          if gh api "$endpoint"; then
-            echo "$GITHUB_ACTOR is member of ${owner}'s team '${repository}-${team}'"
-            echo "is_team_member=true" >> $GITHUB_ENV
-          fi
+          permission="$(gh api --jq .permission "/repos/$GITHUB_REPOSITORY/collaborators/$GITHUB_ACTOR/permission")"
+          echo "repo_permission=$permission" >> $GITHUB_ENV
 
       - id: check_files_changed
         name: Checks if disallowed content has been changed
-        if: env.is_team_member != 'true'
+        if: env.repo_permission != 'admin'
         uses: dorny/paths-filter@v2
         with:
           list-files: 'shell'
@@ -70,7 +63,7 @@ jobs:
               - '!docs/**'
 
       - id: comment_on_disallowed
-        if: env.is_team_member != 'true' && steps.check_files_changed.outputs.disallowed == 'true'
+        if: steps.check_files_changed.outputs.disallowed == 'true'
         env:
           DOCS_LOC: "/${{ github.repository }}/tree/${{ github.base_ref }}/docs"
           REVERT_COMMAND: '`git checkout origin/main <filename>`'


### PR DESCRIPTION
Checking team membership would require two API calls, one for the
repo admin team, and one for the org level admin. This check allows
us to check the "outcome" of those combined team memberships, and
is actually what we need.

Also removed the first condition in the final step, as we shouldn't
need it; checking if disallowed is true should be enough.

Addresses #55.
