### PR TITLE
Fix broken table

### DIFF
--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -194,7 +194,7 @@ We run checks on Markdown content when it is added or changed using the [DavidAn
 The standard rules used are described in the following table; the rule names refer to the technical identifiers used in the configuration.
 
 |Rule Description|Rule Name|
-|-|-|
+|:---|:---|
 |Heading levels should only increment by one level at a time|`heading-increment`|
 |The syntax for links should be the right way round|`no-reversed-links`|
 |There must be a space after the hash or hashes on a heading|`no-missing-space-atx`|


### PR DESCRIPTION
The table in section _Standard Rules_ is broken on SAP Help Portal:
https://help.sap.com/webcomponents/products/open-documentation-initiative/contribution-guidelines/content-contribution_style-guidelines.html

Probably the second line of the table for the indentation is the root cause. GitHub flavored Markdown may be more forgiving in this regard.