### PR TITLE
change ref from id to name

### DIFF
--- a/.github/workflows/community-id-requester.yaml
+++ b/.github/workflows/community-id-requester.yaml
@@ -88,5 +88,5 @@ jobs:
         name: Ask for SAP Community profile URL if label added for first time and no prev labeled issue / pr
         if: env.LABELADDITIONCOUNT == 1 && env.OBJECTCOUNT <= 1
         run: |
-          printf "Thank you for your valuable ${CONTRIBUTIONTYPE} contribution, @${CONTRIBUTOR}! So that we can [recognize your contribution in SAP Community](https://github.com/SAP-docs/contribution-guidelines/blob/main/docs/recognition.md), please tell us your SAP Community profile URL in a reply to this comment; don't include any other text, just the URL on its own, like this:\n\n\`\`\`\nhttps://people.sap.com/your-user-id\n\`\`\`\n\nThanks!" \
+          printf "Thank you for your valuable ${CONTRIBUTIONTYPE} contribution, @${CONTRIBUTOR}! So that we can [recognize your contribution in SAP Community](https://github.com/SAP-docs/contribution-guidelines/blob/main/docs/recognition.md), please tell us your SAP Community profile URL in a reply to this comment; don't include any other text, just the URL on its own, like this:\n\n\`\`\`\nhttps://people.sap.com/your-user-name\n\`\`\`\n\nThanks!" \
           | gh $OBJECTTYPE comment $OBJECTNR --body-file -


### PR DESCRIPTION
In a [comment to the Collaboration Missions blog post](https://blogs.sap.com/2021/05/27/collaboration-missions-for-the-open-documentation-initiative/comment-page-1/#comment-578556) it was pointed out that the wording / example was potentially confusing, as it used "id" and "name" interchangeably. This PR fixes the wording.
