### PR TITLE
Remove redundant links

### DIFF
--- a/docs/content-contribution/style-guidelines.md
+++ b/docs/content-contribution/style-guidelines.md
@@ -2,13 +2,6 @@
 
 This document outlines some style guidelines that we recommend when contributing content in Markdown. They are not mandatory, but they help us to include your contribution more easily.
 
-* [Language](#language)
-* [Section Headings](#section-headings)
-* [Links](#links)
-* [Formatting of Inline Elements](#formatting-of-inline-elements)
-* [Code Snippet Formatting](#code-snippet-formatting)
-* [Note Types](#note-types)
-
 ## Language
 
 * Use US English.


### PR DESCRIPTION
On this page, one can already navigate to the main sections by using the links on the right (_In this topic_):
https://help.sap.com/webcomponents/products/open-documentation-initiative/contribution-guidelines/content-contribution_style-guidelines.html

So the links at the beginning of this page are redundant.