### PR TITLE
remove extraneous title links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,19 +3,3 @@
 Welcome to the general guidelines for contributing to SAP documentation. These guidelines explain how you can contribute to our documentation, what the overall process is, and what you can expect.
 
 These are general contribution guidelines. There may be additional guidelines that are specific to particular documentation sets - you'll find those specifics in the `CONTRIBUTING.md` files in the corresponding repositories for those documentation sets on GitHub.
-
-Here's what you can find in these guidelines:
-
-- [Contributing to SAP Documentation](contributing.md)
-- [The Contributor License Agreement Process](cla.md)
-- [What to Expect](what-to-expect.md)
-- [Contribution Recognition in SAP Community](recognition.md)
-- [Code of Conduct](code-of-conduct.md)
-- [Dos and Don'ts](dos-and-donts.md)
-- [How to Contribute Feedback](feedback.md)
-- [How to Contribute Content](content-contribution/README.md)
-  - [The Overall Process](content-contribution/overall-process.md)
-  - [What Makes a Good Contribution](content-contribution/good-contribution.md)
-  - [Markdown Basics](content-contribution/markdown-basics.md)
-  - [Use of SAP Terminology](content-contribution/sap-terminology.md)
-  - [Style Guidelines](content-contribution/style-guidelines.md)


### PR DESCRIPTION
These links are nice but not needed because they're shown on the left hand side in the SAP Help Portal. So let's get rid!