### PR TITLE
Address unwanted heading error in blockquotes 

### DIFF
--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -42,12 +42,12 @@ jobs:
       run: "echo ::add-matcher::.github/workflows/markdownlint/problem-matcher.json"
 
     - id: install_linter
-      name: Install linting tool and custom rule
+      name: Install linting tool, custom rule and rule helpers
       run: |
         npm install \
           --no-package-lock \
           --no-save \
-          markdownlint-cli markdownlint-rule-titlecase
+          markdownlint-cli markdownlint-rule-titlecase markdownlint-rule-helpers
 
     - id: run_linter
       if: steps.check_files_changed.outputs.changed_files
@@ -55,5 +55,6 @@ jobs:
       run: |
         npx markdownlint \
           --config .github/workflows/markdownlint/config.yaml \
+          --rules .github/workflows/markdownlint/md901 \
           --rules markdownlint-rule-titlecase \
           ${{ steps.check_files_changed.outputs.changed_files }}

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -3,8 +3,8 @@ default: false
 
 # These specific rules are active.
 # See https://github.com/DavidAnson/markdownlint#rules--aliases for details.
-heading-increment: true
 no-reversed-links: true
 no-missing-space-atx: true
 no-multiple-space-atx: true
 titlecase-rule: true
+heading-increment-no-blockquote: true

--- a/.github/workflows/markdownlint/md901.js
+++ b/.github/workflows/markdownlint/md901.js
@@ -12,7 +12,8 @@ module.exports = {
     let prevLevel = 0;
     filterTokens(params, "heading_open", function forToken(token) {
       const level = Number.parseInt(token.tag.slice(1), 10);
-      if ((! token.line.match(/^> ?/)) && prevLevel && (level > prevLevel)) {
+      if (token.line.match(/^\s*> ?/)) return;
+      if (prevLevel && (level > prevLevel)) {
         addErrorDetailIf(onError, token.lineNumber,
           "h" + (prevLevel + 1), "h" + level);
       }

--- a/.github/workflows/markdownlint/md901.js
+++ b/.github/workflows/markdownlint/md901.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+"use strict";
+
+const { addErrorDetailIf, filterTokens } = require("markdownlint-rule-helpers");
+
+module.exports = {
+  "names": [ "MD901", "heading-increment-no-blockquote" ],
+  "description": "Custom version of MD001. Heading levels should only increment by one level at a time, except if in a blockquote",
+  "tags": [ "headings", "headers" ],
+  "function": function MD901(params, onError) {
+    let prevLevel = 0;
+    filterTokens(params, "heading_open", function forToken(token) {
+      const level = Number.parseInt(token.tag.slice(1), 10);
+      if ((! token.line.match(/^> ?/)) && prevLevel && (level > prevLevel)) {
+        addErrorDetailIf(onError, token.lineNumber,
+          "h" + (prevLevel + 1), "h" + level);
+      }
+      prevLevel = level;
+    });
+  }
+};


### PR DESCRIPTION
Sometimes two markdown elements are combined: Specifically, we see the use of headings (e.g. `###`) *inside of* a blockquote (`>`) like this:

```
> ### Some Heading
```

The standard Markdown linting, specifically rule [MD001](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md001), does not expect this and will raise an error when an error is not wanted. Here is an example of where this has happened:

[Update Cloning_Repositories_7a68bfa.md Markdown linter](https://github.com/SAP-docs/btp-business-application-studio/runs/3948413871?check_suite_focus=true)

The approach here is to replace the standard MD001 with a custom one (MD901) that avoids raising an error if the heading is combined with a blockquote.
