### PR TITLE
Update SAPterm link

### DIFF
--- a/docs/content-contribution/sap-terminology.md
+++ b/docs/content-contribution/sap-terminology.md
@@ -7,5 +7,5 @@ When preparing a content contribution, via a pull request, ensure that the appro
 The [SAP Terminology Database][sap-term], also known as SAPterm, gives you access to thousands of terminology entries in use at SAP. Use this database when preparing your content contribution. You may also find the [SAP Glossary][sap-glossary] useful.
 
 
-[sap-term]: http://www.sapterm.com/
+[sap-term]: https://www.sapterm.com/sap/bc/webdynpro/sap/sterm_webaccess#
 [sap-glossary]: https://help.sap.com/glossary/


### PR DESCRIPTION
Hi @qmacro,

apparently www.sapterm.com alone does not work any longer.

I suggest to use this one that I found in the intranet. Solves #89.

Fine with you?

Cheers,
Jens